### PR TITLE
change from id-display to name-display on confim-page

### DIFF
--- a/lib/questionary1/Web/Dispatcher.pm
+++ b/lib/questionary1/Web/Dispatcher.pm
@@ -89,11 +89,40 @@ post '/confirm' => sub {
 
     $c->session->set('remarks' => $remarks);
 
+    # ここで occupation_id と drink_id を session から取得する
+    my $occupation_id = $c->session->get('occupation_id');
+    my $drink_id      = $c->session->get('drink_id');
+
+    # warn "occupation_id: $occupation_id";  # <-- ログ出力
+    # warn "drink_id: $drink_id";            # <-- ログ出力
+
+    # データベース接続を作成
+    use questionary1::Web::Config;
+    my $dbh = DBI->connect(
+        "DBI:mysql:dbname=" . questionary1::Web::Config::get('DB_NAME') . ";host=" . questionary1::Web::Config::get('DB_HOST'),
+        questionary1::Web::Config::get('DB_USER'),
+        questionary1::Web::Config::get('DB_PASS'),
+        { mysql_enable_utf8 => 1 }
+    );
+
+    # occupation_id に対応する職業名を取得
+    my $occupation_name = $dbh->selectrow_array(
+        "SELECT name FROM occupation WHERE id = ?", undef, $occupation_id
+    );
+
+    # drink_id に対応する飲み物名を取得
+    my $drink_name = $dbh->selectrow_array(
+        "SELECT name FROM drink WHERE id = ?", undef, $drink_id
+    );
+
+    # warn "occupation_name: $occupation_name";  # <-- ログ出力
+    # warn "drink_name: $drink_name";            # <-- ログ出力
+
     return $c->render('confirm.tx', {
         name       => $c->session->get('name'),
         birthdate     => $c->session->get('birthdate'),
-        occupation_id => $c->session->get('occupation_id'),
-        drink_id      => $c->session->get('drink_id'),
+        occupation_name => $occupation_name,
+        drink_name      => $drink_name,
         remarks    => $remarks,
     });
 };

--- a/tmpl/confirm.tx
+++ b/tmpl/confirm.tx
@@ -8,9 +8,9 @@
     <form action="/submit" method="POST">
         <div class="alert alert-light border mt-4" style="padding: 15px; border-radius: 10px;">
             <p><strong>名前:</strong> <: $name :></p>
-            <p><strong>年齢:</strong> <: $birthdate :></p>
-            <p><strong>職業:</strong> <: $occupation_id :></p>
-            <p><strong>よく飲むお酒:</strong> <: $drink_id :></p>
+            <p><strong>誕生日:</strong> <: $birthdate :></p>
+            <p><strong>職業:</strong> <: $occupation_name :></p>
+            <p><strong>よく飲むお酒:</strong> <: $drink_name :></p>
             <p><strong>備考:</strong> <: $remarks :></p>
         </div>
 


### PR DESCRIPTION
### 概要
確認ページにおいて、`occupation_id` と `drink_id` が数値（ID）として表示されていたのを、  
それぞれの **名前**（例：会社員 / ビール）で表示するように修正。  

### 変更点
- 確認ページで `occupation_id` / `drink_id` を対応する名前で表示するように変更
- `lib/questionary1/Web/Dispatcher.pm` において、セッションから `occupation_id` / `drink_id` を取得し、  
  データベースから対応する名前を取得する処理を追加
- `tmpl/confirm.tx` の表示内容を `occupation_name` / `drink_name` に修正

### 修正ファイル
- `lib/questionary1/Web/Dispatcher.pm`
- `tmpl/confirm.tx`

### 動作確認
- ローカル環境で `carton exec perl -Ilib script/questionary1-server` を実行し、エラーなく起動することを確認
- 確認ページで `occupation` と `drink` が名前で表示されることを確認
- MySQL で `SELECT * FROM member;` を実行し、`occupation_id` / `drink_id` が正しく保存されていることを確認